### PR TITLE
Fixed Implict declaration of method pdesireaudio_uhqa_mode

### DIFF
--- a/sound/soc/codecs/wcd9xxx-common.h
+++ b/sound/soc/codecs/wcd9xxx-common.h
@@ -187,6 +187,10 @@ extern void wcd9xxx_enable_high_perf_mode(struct snd_soc_codec *codec,
 				struct wcd9xxx_clsh_cdc_data *clsh_d,
 				u8 uhqa_mode, u8 req_state, bool req_type);
 
+extern void pdesireaudio_uhqa_mode(struct snd_soc_codec *codec,
+				struct wcd9xxx_clsh_cdc_data *clsh_d,
+				u8 uhqa_mode, u8 req_state, bool req_type);
+
 extern void wcd9xxx_clsh_init(struct wcd9xxx_clsh_cdc_data *clsh,
 			      struct wcd9xxx_resmgr *resmgr);
 


### PR DESCRIPTION
pdesireaudio_uhqa_mode Method didn't worked due missing declaration on wcd9xxx-common.h

So it ws partly working, this commit fix it

Commit made by PDesire (Tristan Marsell) <tristan.marsell@t-online.de>